### PR TITLE
添加tabbed语法的typst导出

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -437,14 +437,20 @@ function toTypst(tree, options) {
       case 'detailsContainerSummary': {
         return all(node, parse).join('')
       }
-      // case 'tabbedContainer': {
-      //   console.log(node)
-      //   return ''
-      // }
-      // case 'tabbedContainerTitle': {
-      //   console.log(node)
-      //   return ''
-      // }
+      case 'tabbedContainer': {
+        indentPar.push(true)
+        const title = unquote(parse(node.children[0]))
+        node.children = node.children.slice(1)
+        // const ret = '#tabbed[{0}][{1}]'.format(unquote(title), all(node, parse).join(''))
+        
+        // Simply flatten the content
+        const ret = all(node, parse)
+        indentPar.pop()
+        return ret
+      }
+      case 'tabbedContainerTitle': {
+        return all(node, parse).join('')
+      }
       default: {
         console.error(ERROR + 'Unsupported node type: {0}'.format(node.type))
         console.error(JSON.stringify(node, null, '\t'))


### PR DESCRIPTION
由于typst不支持tabbed语法，目前使用的方式是将把tabbed中的内容提取出来。

后续如果typst添加tabbed支持，可以将tab一并导出。